### PR TITLE
group file export actions in the File menu

### DIFF
--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -661,9 +661,8 @@ void QC_ApplicationWindow::initActions(void)
 
     menu->addSeparator();
 
-    actionFactory.addGUI(menu, this, {RS2::ActionFileClose
-                                      ,RS2::ActionFilePrint
-                                      ,RS2::ActionFilePrintPDF});
+	actionFactory.addGUI(menu, this, {RS2::ActionFileClose
+									  , RS2::ActionFilePrint});
     action= actionFactory.addGUI(menu, fileToolBar, this, RS2::ActionFilePrintPreview);
     connect(this, SIGNAL(printPreviewChanged(bool)), action, SLOT(setChecked(bool)));
 

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -638,12 +638,11 @@ void QC_ApplicationWindow::initActions(void)
     menu->setObjectName("File");
     fileToolBar->setWindowTitle(tr("File"));
 
-    actionFactory.addGUI(menu, fileToolBar, this, {RS2::ActionFileNew
+	actionFactory.addGUI(menu, fileToolBar, this, {RS2::ActionFileNew
                                                    ,RS2::ActionFileNewTemplate
                                                    ,RS2::ActionFileOpen
                                                    ,RS2::ActionFileSave
-                                                   ,RS2::ActionFileSaveAs
-                                                   ,RS2::ActionFileExport});
+													,RS2::ActionFileSaveAs});
 
     subMenu = menu->addMenu( QIcon(":/actions/fileimport.png"), tr("Import"));
     subMenu->setObjectName("Import");
@@ -654,14 +653,19 @@ void QC_ApplicationWindow::initActions(void)
 
     // Import Block:
     actionFactory.addGUI(subMenu, this, RS2::ActionBlocksImport);
+	subMenu = menu->addMenu( QIcon(":/actions/fileimport.png"), tr("Export"));
+	subMenu->setObjectName("Export");
+	actionFactory.addGUI(subMenu, actionHandler, RS2::ActionFileExportMakerCam);
+	actionFactory.addGUI(subMenu, this, {RS2::ActionFilePrintPDF
+										, RS2::ActionFileExport});
 
     menu->addSeparator();
+
     actionFactory.addGUI(menu, this, {RS2::ActionFileClose
                                       ,RS2::ActionFilePrint
                                       ,RS2::ActionFilePrintPDF});
     action= actionFactory.addGUI(menu, fileToolBar, this, RS2::ActionFilePrintPreview);
     connect(this, SIGNAL(printPreviewChanged(bool)), action, SLOT(setChecked(bool)));
-    actionFactory.addGUI(menu, actionHandler, RS2::ActionFileExportMakerCam);
 
     menu->addSeparator();
     actionFactory.addGUI(menu, this, RS2::ActionFileQuit);

--- a/librecad/src/main/qc_applicationwindow.cpp
+++ b/librecad/src/main/qc_applicationwindow.cpp
@@ -661,13 +661,13 @@ void QC_ApplicationWindow::initActions(void)
 
     menu->addSeparator();
 
-	actionFactory.addGUI(menu, this, {RS2::ActionFileClose
-									  , RS2::ActionFilePrint});
-    action= actionFactory.addGUI(menu, fileToolBar, this, RS2::ActionFilePrintPreview);
-    connect(this, SIGNAL(printPreviewChanged(bool)), action, SLOT(setChecked(bool)));
+	action= actionFactory.addGUI(menu, fileToolBar, this, RS2::ActionFilePrintPreview);
+	action= actionFactory.addGUI(menu, fileToolBar, this, RS2::ActionFilePrint);
+	connect(this, SIGNAL(printPreviewChanged(bool)), action, SLOT(setChecked(bool)));
 
     menu->addSeparator();
-    actionFactory.addGUI(menu, this, RS2::ActionFileQuit);
+	actionFactory.addGUI(menu, this, RS2::ActionFileClose);
+	actionFactory.addGUI(menu, this, RS2::ActionFileQuit);
     menu->addSeparator();
     addToolBar(Qt::TopToolBarArea, fileToolBar); //tr("File");
 

--- a/librecad/src/ui/qg_actionfactory.cpp
+++ b/librecad/src/ui/qg_actionfactory.cpp
@@ -259,7 +259,7 @@ QAction* QG_ActionFactory::createAction(	RS2::ActionType id, QObject* obj,
         break;
 
     case RS2::ActionFileExport:
-        action = new QAction( QIcon(":/actions/fileexport.png"), tr("&Export..."), NULL);
+		action = new QAction( QIcon(":/actions/fileexport.png"), tr("&Export as image"), NULL);
         connect( action, SIGNAL( triggered()), obj, SLOT(slotFileExport()));
         break;
 


### PR DESCRIPTION
Since we have 3 "File Export" menu entries now, it makes sense to group them in a submenu.
